### PR TITLE
todo削除機能の実装

### DIFF
--- a/src/components/TodoItem.jsx
+++ b/src/components/TodoItem.jsx
@@ -1,14 +1,20 @@
-export function TodoItem({ todo, index }) {
+export function TodoItem({ todo, index, onDelete }) {
   return (
-    <tr key={todo.id}>
-      <td>{index + 1}</td>
+    <tr key={index + 1}>
+      <td>{todo.id}</td>
       <td>{todo.title}</td>
       <td>{todo.date}</td>
       <td>
         <button>{todo.status}</button>
       </td>
       <td>
-        <button>✖️</button>
+        <button
+          onClick={() => {
+            onDelete(todo.id);
+          }}
+        >
+          ✖️
+        </button>
       </td>
     </tr>
   );

--- a/src/components/TodoItem.jsx
+++ b/src/components/TodoItem.jsx
@@ -1,6 +1,6 @@
-export function TodoItem({ todo, index, onDelete }) {
+export function TodoItem({ todo, onDelete }) {
   return (
-    <tr key={index + 1}>
+    <tr key={todo.id}>
       <td>{todo.id}</td>
       <td>{todo.title}</td>
       <td>{todo.date}</td>

--- a/src/components/TodoItem.jsx
+++ b/src/components/TodoItem.jsx
@@ -1,6 +1,6 @@
 export function TodoItem({ todo, onDelete }) {
   return (
-    <tr key={todo.id}>
+    <tr>
       <td>{todo.id}</td>
       <td>{todo.title}</td>
       <td>{todo.date}</td>

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -1,6 +1,7 @@
 import { Radio } from "./Radio.jsx";
 import { TodoItem } from "./TodoItem.jsx";
 import { useState } from "react";
+// TodoListコンポーネント
 export function TodoList() {
   const todoData = [
     {
@@ -25,7 +26,7 @@ export function TodoList() {
   const [todos, setTodos] = useState(todoData);
   const [todoName, setTodoName] = useState("");
   const [dueDate, setDueDate] = useState("");
-
+  //タスクの追加
   const AddTodo = (e) => {
     e.preventDefault();
     setTodos((todos) => [
@@ -40,6 +41,11 @@ export function TodoList() {
 
     setTodoName("");
     setDueDate("");
+  };
+  //タスクの削除
+  const DeleteTodo = (idDelete) => {
+    const newTodos = todos.filter((todo) => todo.id !== idDelete);
+    setTodos(newTodos);
   };
   return (
     <>
@@ -56,7 +62,12 @@ export function TodoList() {
         </thead>
         <tbody>
           {todos.map((todo, index) => (
-            <TodoItem key={todo.id} todo={todo} index={index} />
+            <TodoItem
+              key={todo.id}
+              todo={todo}
+              index={index}
+              onDelete={DeleteTodo}
+            />
           ))}
         </tbody>
       </table>

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -27,7 +27,7 @@ export function TodoList() {
   const [todoName, setTodoName] = useState("");
   const [dueDate, setDueDate] = useState("");
   //タスクの追加
-  const AddTodo = (e) => {
+  const addTodo = (e) => {
     e.preventDefault();
     setTodos((todos) => [
       ...todos,
@@ -43,9 +43,12 @@ export function TodoList() {
     setDueDate("");
   };
   //タスクの削除
-  const DeleteTodo = (idDelete) => {
-    const newTodos = todos.filter((todo) => todo.id !== idDelete);
+  const deleteTodo = (targetId) => {
+    const newTodos = todos.filter((todo) => todo.id !== targetId);
+    // IDの番号を振り直す
+    const newId = newTodos.map((todo, index) => ({ ...todo, id: index + 1 }));
     setTodos(newTodos);
+    setTodos(newId);
   };
   return (
     <>
@@ -66,7 +69,7 @@ export function TodoList() {
               key={todo.id}
               todo={todo}
               index={index}
-              onDelete={DeleteTodo}
+              onDelete={deleteTodo}
             />
           ))}
         </tbody>
@@ -85,7 +88,7 @@ export function TodoList() {
         value={dueDate}
         onChange={(e) => setDueDate(e.target.value)}
       />
-      <button onClick={AddTodo}>追加</button>
+      <button onClick={addTodo}>追加</button>
     </>
   );
 }

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -65,12 +65,7 @@ export function TodoList() {
         </thead>
         <tbody>
           {todos.map((todo, index) => (
-            <TodoItem
-              key={todo.id}
-              todo={todo}
-              index={index}
-              onDelete={deleteTodo}
-            />
+            <TodoItem key={todo.id} todo={todo} onDelete={deleteTodo} />
           ))}
         </tbody>
       </table>

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -44,11 +44,10 @@ export function TodoList() {
   };
   //タスクの削除
   const deleteTodo = (targetId) => {
-    const newTodos = todos.filter((todo) => todo.id !== targetId);
-    // IDの番号を振り直す
-    const newId = newTodos.map((todo, index) => ({ ...todo, id: index + 1 }));
+    const newTodos = todos
+      .filter((todo) => todo.id !== targetId)
+      .map((todo, index) => ({ ...todo, id: index + 1 }));
     setTodos(newTodos);
-    setTodos(newId);
   };
   return (
     <>
@@ -64,7 +63,7 @@ export function TodoList() {
           </tr>
         </thead>
         <tbody>
-          {todos.map((todo, index) => (
+          {todos.map((todo) => (
             <TodoItem key={todo.id} todo={todo} onDelete={deleteTodo} />
           ))}
         </tbody>


### PR DESCRIPTION
<!-- この内容を全てPRに貼り付ける -->

## 目的

追加したタスクを削除できるようにする

## 関連するタスク
ID削除時のID番号の更新（連番に更新）

## 実施内容

タスクの削除

## 前提条件
1. 初期表示時３つのタスクが表示された状態
2. ラジオボタン「すべて」「作業中」「完了」の３つが表示された状態

## テスト

## テストケース1 　初期表示されているタスクの削除
### 手順
1. ID１の削除ボタンを押下

## 期待結果
1. ID1のタスクが削除される
2.  残りのタスクのIDが1.2と連番になる
3. ID1のタスクが削除される


## テストケース2　追加したタスクの削除
### 手順
1. 入力フォームに「ほげ」と入力
4. 日付選択欄で「2025/07/14」を選択
5. 追加ボタンの押下
6. 追加されたID4の削除ボタンを押下

## 期待結果
1. ID4のタスクが追加される
2. 追加されたID4のタスクが削除される


